### PR TITLE
Level III bucket also has CORS headers now

### DIFF
--- a/app/radar/libnexrad/loaders_nexrad.js
+++ b/app/radar/libnexrad/loaders_nexrad.js
@@ -110,7 +110,7 @@ function get_latest_level_3_url(station, product, index, callback, date) {
         fullURL = ut.preventFileCaching(fullURL);
 
         const headers = new Headers().append('Cache-Control', 'no-cache');
-        fetch(ut.phpProxy + fullURL, {cache: 'no-store', headers: headers}).then(response => response.text())
+        fetch(fullURL, {cache: 'no-store', headers: headers}).then(response => response.text())
         .then(function(data) {
         //$.get(ut.phpProxy + fullURL, function (data) {
             try {


### PR DESCRIPTION
CORS headers have now been supported by Unidata for the `unidata-nexrad-level3` bucket, eliminating the need for passing requests to such via a CORS proxy.