### PR TITLE
Improve Vincenty implementation

### DIFF
--- a/app/radar/plot/dest_vincenty.js
+++ b/app/radar/plot/dest_vincenty.js
@@ -5,7 +5,7 @@ function dest_vincenty(start, distance, bearing) {
     const one_minus_f = 1 - f;
 
     if (distance === 0) {
-        return [start.lat, start.lng];
+        return [start.lng, start.lat];
     }
 
     const to_rad = deg => deg * Math.PI / 180;


### PR DESCRIPTION
This PR proposes an improved version of the existing Vincenty implementation in `dest_vincenty.js`, with the following main differences:

- Switch from numerically solving for $\sigma$ via fixed-point iteration to using Newton-Raphson with analytical derivatives
- Relax the tolerance to $3 \times 10^{-6}$ radians and maximum iterations to just 6; this has proved to be enough for this radar use case
- Use an improved initial guess for $\sigma$ as follows, instead of the classical $\sigma = s/bA$:

```math
\sigma = \frac{s}{bA} + \frac{f}{6} \sin\alpha_1 \tan U_1 \left(\frac{s}{bA}\right)^2
```